### PR TITLE
fix node-api-v3 typos (npm not mpm. Babel not Apple)

### DIFF
--- a/en-US/2019-01-18-api-design-nodejs-v3/20-mongoose-schema-exercise.txt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/20-mongoose-schema-exercise.txt
@@ -36,7 +36,7 @@ So that right there might satisfy that test.
 So item, like I said, is basically, it's like a to-do item. This is like a very basic API for a to-do app, and you're just filling out these fields for Mongo. So, like I said, check out to lesson three, if we look at the readme, just to go over it one more time.
 
 [00:03:21]
-You're gonna be creating the schemas. It's on lesson three branch. The test command is gonna test models, where there's yarn or MPM, and the things you're gonna be doing is you're gonna be creating the schema for the item resource, you're gonna add the correct fields, and this says look at the test here, you're gonna add the correct validations, also look at the test, the test does exactly what we are expecting.
+You're gonna be creating the schemas. It's on lesson three branch. The test command is gonna test models, where there's yarn or NPM, and the things you're gonna be doing is you're gonna be creating the schema for the item resource, you're gonna add the correct fields, and this says look at the test here, you're gonna add the correct validations, also look at the test, the test does exactly what we are expecting.
 
 [00:03:42]
 For extra credit, if you know how to use Mongo, or if you just wanna take the extra credit and figure out how to do it, I'll give you a hint if you wanna do it, add a compound index to ensure all the tasks in a list have a unique names.

--- a/en-US/2019-01-18-api-design-nodejs-v3/20-mongoose-schema-exercise.web_vtt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/20-mongoose-schema-exercise.web_vtt
@@ -270,7 +270,7 @@ It's on lesson three branch.
 57
 00:03:24.432 --> 00:03:27.939
 The test command is gonna test models,
-where there's yarn or MPM, and
+where there's yarn or NPM, and
 
 58
 00:03:27.939 --> 00:03:31.679

--- a/en-US/2019-01-18-api-design-nodejs-v3/29-read-documents-solution.txt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/29-read-documents-solution.txt
@@ -79,7 +79,7 @@ And that's why you're all like, well, we've been using send, what's going on? Ye
 
 [00:07:47]
 Cool, so now if we run this test,
->> Scott Moss: Yarn test, or I'll do mpm run tests models, I believe. Some of the route tests might fail. They might run, because the route's messed up with the controllers now, but that's fine you can ignore them. It's not models, what is it?
+>> Scott Moss: Yarn test, or I'll do npm run tests models, I believe. Some of the route tests might fail. They might run, because the route's messed up with the controllers now, but that's fine you can ignore them. It's not models, what is it?
 
 [00:08:11]
 Controllers, see, I'm sorry. Okay, so let's see what happened here. Okay. Guess I do have to put a status here, guess you're right. [LAUGH]

--- a/en-US/2019-01-18-api-design-nodejs-v3/29-read-documents-solution.web_vtt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/29-read-documents-solution.web_vtt
@@ -676,7 +676,7 @@ Cool, so now if we run this test,
 
 146
 00:07:55.680 --> 00:08:01.020
-or I'll do mpm run tests models,
+or I'll do npm run tests models,
 I believe.
 
 147

--- a/en-US/2019-01-18-api-design-nodejs-v3/42-next-steps.txt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/42-next-steps.txt
@@ -25,7 +25,7 @@ And yeah, that's it. Any questions about anything specific that came here in min
 >> Scott Moss: Man, there are tons of package authentication. So JSON, so JSON web token is the one that I was using. That's a really good one.
 
 [00:02:26]
-I highly recommend using it. The only thing about JSON web token is that you have to manually set all the stuff up like I did. If you don't wanna do all that, if you just look up mpmjwt, there's an express JWT right here that uses JSON web token and creates all that middle ware for you.
+I highly recommend using it. The only thing about JSON web token is that you have to manually set all the stuff up like I did. If you don't wanna do all that, if you just look up npmjwt, there's an express JWT right here that uses JSON web token and creates all that middle ware for you.
 
 [00:02:42]
 The whole protect middle ware that we had to write, this thing does it for you. So you don't have to write it. I just don't like using stuff like that. I'll just write it myself. But yeah, you can totally use this. You can see right now it does all that stuff for you automatically.

--- a/en-US/2019-01-18-api-design-nodejs-v3/42-next-steps.web_vtt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/42-next-steps.web_vtt
@@ -237,7 +237,7 @@ the stuff up like I did.
 51
 00:02:31.250 --> 00:02:36.910
 If you don't wanna do all that, if you
-just look up mpmjwt, there's an express
+just look up npmjwt, there's an express
 
 52
 00:02:36.910 --> 00:02:42.350

--- a/en-US/2019-01-18-api-design-nodejs-v3/7-setup-code-express.txt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/7-setup-code-express.txt
@@ -32,7 +32,7 @@ This project is set up using Babble, so you'll see some ES6 stuff, like imports 
 So all these files in the source folder aren't being executed, they're being transpiled, and it's gonna execute it in another dist folder. And I did that because I just wanted to use the ES6 though. I can't write code without it anymore, so I tried it and I was like I'm just not gonna do it, I just can't, I can't go back.
 
 [00:02:47]
-So I'm sorry, you guys gotta deal with the Apple stuff. Okay, cool, so what I'm gonna do is I was gonna just free hand some code here to get us warmed up in and a little knowledgeable about express. Because this first exercise you're just gonna build a hello world, welcome to express application.
+So I'm sorry, you guys gotta deal with the Babel stuff. Okay, cool, so what I'm gonna do is I was gonna just free hand some code here to get us warmed up in and a little knowledgeable about express. Because this first exercise you're just gonna build a hello world, welcome to express application.
 
 [00:03:04]
 And that kind of just does the very minimal. But first I'm gonna show you some of the things in express that you can do. And then later on the course we're gonna go into detail about every single thing that I'm showing you here. So this is just a primer just to get you to get something going.

--- a/en-US/2019-01-18-api-design-nodejs-v3/7-setup-code-express.txt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/7-setup-code-express.txt
@@ -44,7 +44,7 @@ Just to see what's happening and then give you some context and some questions t
 First thing is, install dependencies with yarn. I prefer to do it with yarn because I lock the versions with the yarn lock. So that guarantees you'll always have the right versions, because we've had problems in the past with the course where the dependencies would get updated, and then the repo would get broken.
 
 [00:03:55]
-So if you use yarn, you'll have the locked versions. MPM does locking as well, but I didn't set up the locking file with MPM cuz I don't like MPM. [LAUGH] So yeah I prefer to use yarn, but you can also use mpm. So install the dependencies. The second thing you're gonna do is you're gonna create a route that sends back some json.
+So if you use yarn, you'll have the locked versions. NPM does locking as well, but I didn't set up the locking file with NPM cuz I don't like NPM. [LAUGH] So yeah I prefer to use yarn, but you can also use npm. So install the dependencies. The second thing you're gonna do is you're gonna create a route that sends back some json.
 
 [00:04:13]
 You have no idea how to do that. So I'm gonna show you how to do that. And then the third thing from there is you're gonna create a route that accepts json and just logs it. And then just sends back a response. And then the last thing is you're going to start the server.
@@ -100,7 +100,7 @@ So just pass in a different port. 3,000's a very common one so if you get that e
 It's going to actually start our server. So only thing you have to do from there so you can check out the package that JSON is there's a lot of different files and folders and stuff in here. There's a task called start. So if you run yarn, I'm sorry.
 
 [00:09:20]
-You actually wanna use dev. So you wanna use the dev one. So if you run yarn dev, or if you're using mpm you could do mpm run dev. What's that's gonna do, it's going to build the project. Then after it's built it's going to start the server from the index file, which is index.js, which should then call the start function in the server and then start your server.
+You actually wanna use dev. So you wanna use the dev one. So if you run yarn dev, or if you're using npm you could do npm run dev. What's that's gonna do, it's going to build the project. Then after it's built it's going to start the server from the index file, which is index.js, which should then call the start function in the server and then start your server.
 
 [00:09:41]
 And then from there we should be able to interact with our API. So let's try that.

--- a/en-US/2019-01-18-api-design-nodejs-v3/7-setup-code-express.web_vtt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/7-setup-code-express.web_vtt
@@ -377,17 +377,17 @@ you'll have the locked versions.
 
 80
 00:03:59.170 --> 00:04:00.570
-MPM does locking as well, but
+NPM does locking as well, but
 
 81
 00:04:00.570 --> 00:04:03.140
 I didn't set up the locking file
-with MPM cuz I don't like MPM.
+with NPM cuz I don't like NPM.
 
 82
 00:04:04.154 --> 00:04:08.480
 [LAUGH] So yeah I prefer to use yarn,
-but you can also use mpm.
+but you can also use npm.
 
 83
 00:04:08.480 --> 00:04:09.970
@@ -849,7 +849,7 @@ So you wanna use the dev one.
 182
 00:09:22.550 --> 00:09:27.076
 So if you run yarn dev, or if you're
-using mpm you could do mpm run dev.
+using npm you could do npm run dev.
 
 183
 00:09:27.076 --> 00:09:30.224

--- a/en-US/2019-01-18-api-design-nodejs-v3/7-setup-code-express.web_vtt
+++ b/en-US/2019-01-18-api-design-nodejs-v3/7-setup-code-express.web_vtt
@@ -271,7 +271,7 @@ I just can't, I can't go back.
 58
 00:02:47.450 --> 00:02:50.250
 So I'm sorry,
-you guys gotta deal with the Apple stuff.
+you guys gotta deal with the Babel stuff.
 
 59
 00:02:50.250 --> 00:02:55.310


### PR DESCRIPTION
* corrected various occurrences of mpm - should be npm.
 
* "Babel" stuff not "Apple" stuff.